### PR TITLE
Remove content filter implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,6 @@ Properties
 - ``UnitName``: descriptive name of local installation, default to FQDN
 - ``Uuid``: auto-generated unique identifier
 - ``Proxy``:  can be ``enabled`` or ``disabled``, if ``enabled`` all hotspot traffic will be proxied
-- ``ContentFilter``: can be ``enabled`` or ``disabled``, if enabled along with Proxy, the traffic will be filtered
 - ``Network``: network for clients connected to Dedalo, default to ``192.168.182.0/24``
 - ``LogTraffic``: can be ``enabled`` or ``disabled``, if enabled along with Proxy, the proxy will log all hotspot traffic inside ``/var/log/squid/dedalo.log``
 - ``status``: can be ``enabled`` or ``disabled``, default to ``disabled``
@@ -67,7 +66,6 @@ Example: ::
     AaaUrl=
     AllowOrigins=
     ApiUrl=
-    ContentFilter=disabled
     IcaroHost=hotstpot.nethserver.org
     Id=MyHotel
     LogTraffic=disabled

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-proxyconfig
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-proxyconfig
@@ -23,7 +23,4 @@ if [ $(/sbin/e-smith/config getprop dedalo Proxy) == "enabled" ] && [ $(/sbin/e-
 
     /sbin/e-smith/signal-event nethserver-squid-save
     
-    if [ $(/sbin/e-smith/config getprop dedalo ContentFilter) == "enabled" ] && [ $(/sbin/e-smith/config getprop ufdb status) == "enabled" ]; then
-        /sbin/e-smith/signal-event nethserver-squidguard-save
-    fi
 fi

--- a/root/etc/e-smith/templates/etc/squid/squid.conf/30http_access_40_dedalo
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/30http_access_40_dedalo
@@ -5,15 +5,12 @@
 {
     my $status = $dedalo{'status'} || 'disabled';
     my $proxy = $dedalo{'Proxy'} || 'disabled';
-    my $filter = $dedalo{'ContentFilter'} || 'disabled';
     if ( $status eq 'enabled' && $proxy eq 'enabled' ) {
         $OUT .= "# No authentication on dedalo\n";
         $OUT .= "http_access allow dedalo\n";
-        if ( $filter eq 'disabled') {
-            $OUT .= "# Skip URL rewriter for dedalo\n";
-            $OUT .= "acl dedalo_http_port port 80\n";
-            $OUT .= "acl dedalo_http_port port 443\n";
-            $OUT .= "url_rewrite_access deny dedalo dedalo_http_port\n";
-        }
+        $OUT .= "# Skip URL rewriter for dedalo\n";
+        $OUT .= "acl dedalo_http_port port 80\n";
+        $OUT .= "acl dedalo_http_port port 443\n";
+        $OUT .= "url_rewrite_access deny dedalo dedalo_http_port\n";
     }
 }

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Hotspot.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Hotspot.php
@@ -8,7 +8,6 @@ $L['Configuration_header'] = 'Hotspot unit ${0}';
 $L['LogTraffic_label'] = 'Log traffic';
 $L['Device_label'] = 'Network device';
 $L['Network_label'] = 'Network address';
-$L['ContentFilter_label'] = 'Enable content filter';
 $L['hotspot_assigned_label'] = 'hotspot assigned';
 $L['HotspotProxy_label'] = 'Web proxy';
 $L['Proxy_label'] = 'Enable transparent proxy on hotspot';

--- a/root/usr/share/nethesis/NethServer/Module/Hotspot/Configuration.php
+++ b/root/usr/share/nethesis/NethServer/Module/Hotspot/Configuration.php
@@ -35,7 +35,6 @@ class Configuration extends \Nethgui\Controller\AbstractController implements \N
         $this->declareParameter('Device', Validate::NOTEMPTY, array());
         $this->declareParameter('Network', Validate::CIDR_BLOCK, array('configuration', 'dedalo', 'Network'));
         $this->declareParameter('Proxy', Validate::SERVICESTATUS, array('configuration', 'dedalo', 'Proxy'));
-        $this->declareParameter('ContentFilter', Validate::SERVICESTATUS, array('configuration', 'dedalo', 'ContentFilter'));
         $this->declareParameter('LogTraffic', Validate::SERVICESTATUS, array('configuration', 'dedalo', 'LogTraffic'));
     }
 
@@ -47,7 +46,6 @@ class Configuration extends \Nethgui\Controller\AbstractController implements \N
         $view['Id'] = $this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'Id');
         $view['Unregister'] = $view->getModuleUrl('../Unregister');
         $view['ProxyEnabled'] = $this->getPlatform()->getDatabase('configuration')->getProp('squid', 'status') == "enabled";
-        $view['ContentFilterEnabled'] = $this->getPlatform()->getDatabase('configuration')->getProp('ufdb', 'status') == "enabled";
         if($this->getRequest()->hasParameter('installSuccess')) {
             $this->notifications->message($view->translate('hotspotRegistrationSuccess_notification'));
             $view->getCommandList()->show();

--- a/root/usr/share/nethesis/NethServer/Template/Hotspot/Configuration.php
+++ b/root/usr/share/nethesis/NethServer/Template/Hotspot/Configuration.php
@@ -12,9 +12,6 @@ if ($view['ProxyEnabled']) {
         ->setAttribute('uncheckedValue', 'disabled')
         ->insert($view->checkBox('LogTraffic', 'enabled')->setAttribute('uncheckedValue', 'disabled'))
     ;
-    if($view['ContentFilterEnabled']) {
-        $proxy->insert($view->checkBox('ContentFilter', 'enabled')->setAttribute('uncheckedValue', 'disabled'));
-    }
     echo $proxy;
 }
 


### PR DESCRIPTION
Actual implementation has 2 main problems:

- the content filter can block access to the captive portal hosted on a
remote server
- block page is not reachable from blue to green network


NethServer/dev#5422