### PR TITLE
UI: use hotspot id for registration

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/Hotspot/Wizard/Register.php
+++ b/root/usr/share/nethesis/NethServer/Module/Hotspot/Wizard/Register.php
@@ -49,7 +49,7 @@ class Register extends \Nethgui\Controller\AbstractController
             return $ret;
         }
         foreach ($hotspots as $hotspot) {
-            $ret[] = array($hotspot['name'], $hotspot['name']." (".$hotspot['description'].")");
+            $ret[] = array($hotspot['id'], $hotspot['name']." (".$hotspot['description'].")");
         }
         return $ret;
     }


### PR DESCRIPTION
Avoid error on hotspot with duplicate names.

Nethesis/icaro#67