### PR TITLE
UI: display name of parent hotspot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ Properties
 - ``AllowOrigins``: (optional) hosts allowed to execute CORS requests to Dedalo, automatically calculated from ``SplashPageUrl``
 - ``ApiUrl``: (optional) Sun URL, automatically calculated from ``SplashPageUrl``
 - ``Description``: a descriptive name of local installation, eg: ``MyHotelAtTheSea``
-- ``Id``: name of the Hotspot already present inside Icaro, eg: ``MyHotelCompany``
+- ``Id``: id of the Hotspot already present inside Icaro, eg: ``MyHotelCompany``
+- ``Name``: name of the Hotspot, it's retrieved from the UI using an API call
 - ``SplashPageUrl``:  Wings (capitve portal) URL
 - ``UnitName``: hostname of local installation, default to FQDN
 - ``Uuid``: auto-generated unique identifier

--- a/root/usr/share/nethesis/NethServer/Module/Hotspot/Configuration.php
+++ b/root/usr/share/nethesis/NethServer/Module/Hotspot/Configuration.php
@@ -43,7 +43,11 @@ class Configuration extends \Nethgui\Controller\AbstractController implements \N
         parent::prepareView($view);
         $view['DeviceDatasource'] = \Nethgui\Renderer\AbstractRenderer::hashToDatasource($this->initNetworkDevicesList($view));
         $view['UnitName'] = $this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'UnitName') . " (" .$this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'Uuid'). ")";
-        $view['Id'] = $this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'Id');
+        $name = $this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'Name');
+        if ($name == '') {
+            $name = $this->getPlatform()->getDatabase('configuration')->getProp('dedalo', 'Id');
+        }
+        $view['Id'] = $name;
         $view['Unregister'] = $view->getModuleUrl('../Unregister');
         $view['ProxyEnabled'] = $this->getPlatform()->getDatabase('configuration')->getProp('squid', 'status') == "enabled";
         if($this->getRequest()->hasParameter('installSuccess')) {

--- a/root/usr/share/nethesis/NethServer/Template/Hotspot/Wizard/Register.php
+++ b/root/usr/share/nethesis/NethServer/Template/Hotspot/Wizard/Register.php
@@ -4,6 +4,7 @@
 echo $view->header('IcaroHost')->setAttribute('template', $T('Register_header'));
 
 echo $view->selector('Id', $view::SELECTOR_DROPDOWN);
+echo $view->hidden('NameMap');
 echo $view->textInput('UnitName', $view::STATE_READONLY);
 echo $view->textInput('Description');
 echo $view->selector('Device', $view::SELECTOR_DROPDOWN);


### PR DESCRIPTION
The name is displayed only for newly registered units.
To display the name on already-registered units, unregister and register them again.