### PR TITLE
Regenerate chilli config on save event

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -47,6 +47,7 @@ event_templates($event,
 
 event_actions($event, qw(
     nethserver-dedalo-proxyconfig 20
+    nethserver-dedalo-conf 25
     firewall-adjust 30
 ));
 


### PR DESCRIPTION
Call nethserver-dedalo-conf action on nethserver-dedalo-save event for
regenerate chilli.conf by `dedalo config` command.

Fix NethServer/dev#5475