### PR TITLE
Zone refactor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ The whole process is available from the Server Manager, but these are the requir
 1. Set the ``hotspot`` role to the network interface which will be used by Dedalo.
    The interfarce could also be a VLAN. ::
 
-       db networks setprop enps0 role hotspot
+       db networks setprop enps0 role dedalo
 
 2. Configure at least ``IcaroHost`` and the hotspot ``Id``.
    Please note that the hotspot id should be already present inside Icaro installation.

--- a/root/etc/e-smith/db/networks/migrate/hotspot
+++ b/root/etc/e-smith/db/networks/migrate/hotspot
@@ -1,0 +1,17 @@
+{
+  #
+  # issue XXX - migrate hotspot role to dedalo
+  #
+
+  use esmith::NetworksDB;
+  my $ndb = esmith::NetworksDB->open();
+
+  foreach ($ndb->get_all()) {
+       my $role = $_->prop('role') || next;
+       if ($role eq 'hotspot') {
+           $_->set_prop('role','dedalo');
+       }
+  }
+
+  ''; 
+}

--- a/root/etc/e-smith/templates/etc/shorewall/interfaces/90dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/interfaces/90dedalo
@@ -3,3 +3,12 @@
 #
 
 hotsp	tun-dedalo	tcpflags,nosmurfs
+{
+    use esmith::NetworksDB;
+    my $status = $dedalo{'status'} || 'disabled';
+    my $ndb = esmith::NetworksDB->open_ro() || return;
+    my @device= $ndb->get_all_by_prop('role' => 'hotspot');
+    if ( $status eq 'enabled' &&  defined($device[0]) ) {
+        $OUT .= "ethde\t".$device[0]->key."\tdhcp,nosmurfs,routeback\n";
+    }
+}

--- a/root/etc/e-smith/templates/etc/shorewall/interfaces/90dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/interfaces/90dedalo
@@ -3,12 +3,3 @@
 #
 
 hotsp	tun-dedalo	tcpflags,nosmurfs
-{
-    use esmith::NetworksDB;
-    my $status = $dedalo{'status'} || 'disabled';
-    my $ndb = esmith::NetworksDB->open_ro() || return;
-    my @device= $ndb->get_all_by_prop('role' => 'hotspot');
-    if ( $status eq 'enabled' &&  defined($device[0]) ) {
-        $OUT .= "ethde\t".$device[0]->key."\tdhcp,nosmurfs,routeback\n";
-    }
-}

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base30dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base30dedalo
@@ -9,7 +9,7 @@
     my @device = $ndb->get_all_by_prop('role' => 'hotspot');
     if ( $status eq 'enabled' &&  defined($device[0]) ) {
         $OUT .= "# Avoid duplicated traffic\n";
-        $OUT .= "DROP\thotsp:".$device[0]->key."\tnet\n";
+        $OUT .= "DROP\tethde\tnet\n";
     }
 
 }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/10base30dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/10base30dedalo
@@ -6,10 +6,10 @@
     use esmith::NetworksDB;
     my $status = $dedalo{'status'} || 'disabled';
     my $ndb = esmith::NetworksDB->open_ro() || return;
-    my @device = $ndb->get_all_by_prop('role' => 'hotspot');
+    my @device = $ndb->get_all_by_prop('role' => 'dedalo');
     if ( $status eq 'enabled' &&  defined($device[0]) ) {
         $OUT .= "# Avoid duplicated traffic\n";
-        $OUT .= "DROP\tethde\tnet\n";
+        $OUT .= "DROP\tdedal\tnet\n";
     }
 
 }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/90dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/90dedalo
@@ -16,7 +16,7 @@
         $OUT .= 'ACCEPT  hotsp   $FW     udp     67,68'. "\n";
         $OUT .= 'ACCEPT  hotsp   $FW     udp     53'. "\n";
         $OUT .= "# Avoid duplicated traffic\n";
-        $OUT .= "DROP    hotsp:".$device[0]->key."  any\n";
+        $OUT .= "DROP    ethde  any\n";
         $OUT .= 'ACCEPT  hotsp   net'. "\n";
 
         if ($proxy eq 'enabled') {
@@ -25,7 +25,7 @@
             $OUT .= "ACCEPT    hotsp    \$FW    tcp    3132\n";
             $OUT .= "REDIRECT    hotsp    3131    tcp    80\n";
             $OUT .= "REDIRECT    hotsp    3132    tcp    443\n";
-            $OUT .= "?COMMENT";
+            $OUT .= "?COMMENT\n";
         }
         $OUT .= "DROP    hotsp   \$FW\n";
     }

--- a/root/etc/e-smith/templates/etc/shorewall/rules/90dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/rules/90dedalo
@@ -7,7 +7,7 @@
     my $status = $dedalo{'status'} || 'disabled';
     my $proxy = $dedalo{'Proxy'} || 'disabled';
     my $ndb = esmith::NetworksDB->open_ro() || return;
-    my @device = $ndb->get_all_by_prop('role' => 'hotspot');
+    my @device = $ndb->get_all_by_prop('role' => 'dedalo');
     if ( $status eq 'enabled' &&  defined($device[0]) ) {
         $OUT .= '?COMMENT dedalo'. "\n";
         $OUT .= 'ACCEPT  hotsp   $FW     tcp     3990'. "\n";
@@ -16,7 +16,7 @@
         $OUT .= 'ACCEPT  hotsp   $FW     udp     67,68'. "\n";
         $OUT .= 'ACCEPT  hotsp   $FW     udp     53'. "\n";
         $OUT .= "# Avoid duplicated traffic\n";
-        $OUT .= "DROP    ethde  any\n";
+        $OUT .= "DROP    dedal  any\n";
         $OUT .= 'ACCEPT  hotsp   net'. "\n";
 
         if ($proxy eq 'enabled') {

--- a/root/etc/e-smith/templates/etc/shorewall/zones/50dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/zones/50dedalo
@@ -2,4 +2,4 @@
 # 50dedalo
 #
 hotsp     ipv4
-ethde     ipv4
+dedal     ipv4

--- a/root/etc/e-smith/templates/etc/shorewall/zones/50dedalo
+++ b/root/etc/e-smith/templates/etc/shorewall/zones/50dedalo
@@ -2,3 +2,4 @@
 # 50dedalo
 #
 hotsp     ipv4
+ethde     ipv4

--- a/root/etc/e-smith/templates/opt/icaro/dedalo/config/10base
+++ b/root/etc/e-smith/templates/opt/icaro/dedalo/config/10base
@@ -3,7 +3,7 @@
   use esmith::NetworksDB;
   use NethServer::Password;
   my $ndb = esmith::NetworksDB->open_ro() || return;
-  my @devices = $ndb->get_all_by_prop('role' => 'hotspot');
+  my @devices = $ndb->get_all_by_prop('role' => 'dedalo');
   our $hs_interface = defined($devices[0]) ? $devices[0]->key : '';
   our $hs_network = $dedalo{'Network'} || '';
   my $icaro_host = $dedalo{'IcaroHost'} || '';

--- a/root/usr/share/nethesis/NethServer/Module/Hotspot/Lib/DeviceTrait.php
+++ b/root/usr/share/nethesis/NethServer/Module/Hotspot/Lib/DeviceTrait.php
@@ -32,7 +32,7 @@ trait DeviceTrait
         $interfaces = $this->getPlatform()->getDatabase('networks')->getAll();
         foreach ($interfaces as $interface => $props) {
             if (preg_match('/ethernet|bridge|bond|alias|ipsec|vlan/',$props['type'])) {
-                if ($props['role'] == 'hotspot') {
+                if ($props['role'] == 'dedalo') {
                     return array($interface);
                 }
             }
@@ -44,11 +44,11 @@ trait DeviceTrait
     {
        $interfaces = $this->getPlatform()->getDatabase('networks')->getAll();
        foreach ($interfaces as $interface => $props) {
-           if ($props['role'] == 'hotspot') {
+           if ($props['role'] == 'dedalo') {
                $this->getPlatform()->getDatabase('networks')->setProp($interface, array('role' => ''));
            }
        }
-       $this->getPlatform()->getDatabase('networks')->setProp($v, array('role' => 'hotspot'));
+       $this->getPlatform()->getDatabase('networks')->setProp($v, array('role' => 'dedalo'));
        return TRUE;
     }
 
@@ -62,7 +62,7 @@ trait DeviceTrait
 
         foreach ($devices as $dev => $val) {
             if (preg_match('/ethernet|bridge|bond|alias|ipsec|vlan/',$val['type'])) {
-                if ($val['role'] == 'hotspot') {
+                if ($val['role'] == 'dedalo') {
                     $networks[$dev] =  $dev. ' - ' . $view->translate('hotspot_assigned_label');
                 }
             }


### PR DESCRIPTION
Currently if there is a rule that accept all traffic from the hotspot role to the red one, the first packet is accepted even if client is not yet authenticated to the hotspot.
By the way, the package is dropped as soon as the connection is in ESTABLISHED state.
In this context, as a side effect, the first packet of the connection is duplicated.

The patch allow the creation of hotspot rules without leaking traffic from the physical interface.
This implementation must be merged together with NethServer/nethserver-firewall-base#83.

Limitation: the hotspot role can't be used to create new rules. We need to extend the core to support extra roles from new packages.
