### PR TITLE
Prevent corrupted squid access log

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_50_dedalo
+++ b/root/etc/e-smith/templates/etc/squid/squid.conf/20acl_50_dedalo
@@ -17,6 +17,5 @@
         } else {
             $OUT .= "access_log none dedalo\n";
         }
-        $OUT .= "access_log daemon:/var/log/squid/access.log squid !dedalo\n";
     }
 }


### PR DESCRIPTION
This configuration is no more needed since squid default logging strategy has been
changed in the following commits:

- https://github.com/NethServer/nethserver-squid/commit/01cad16e61e9e493fe76b3f9e95d75631908fc38
- https://github.com/NethServer/nethserver-squid/commit/08040daf33f6b52a3031999faf87724e669bd4b2

NethServer/dev#5792