### PR TITLE
config: add dedalo_users_auth service

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -35,6 +35,10 @@ event_templates($event,
    '/opt/icaro/dedalo/config'
 );
 
+event_services($event, qw(
+    dedalo_users_auth restart
+));
+
 #
 # nethserver-dedalo-save event
 #

--- a/root/etc/e-smith/db/configuration/defaults/dedalo_users_auth/status
+++ b/root/etc/e-smith/db/configuration/defaults/dedalo_users_auth/status
@@ -1,0 +1,1 @@
+disabled

--- a/root/etc/e-smith/db/configuration/defaults/dedalo_users_auth/type
+++ b/root/etc/e-smith/db/configuration/defaults/dedalo_users_auth/type
@@ -1,0 +1,1 @@
+service

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-conf
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-conf
@@ -27,5 +27,13 @@ if [ -z "$uuid" ]; then
     /sbin/e-smith/config setprop dedalo Uuid $(uuidgen)
 fi
 
+# Make sure dedalo_users_auth is started if the unit is registerd
+status=$(sbin/e-smith/config getprop dedalo status)
+if [[ "$status" == "enabled" && -f "/root/.dedalo-token" ]]
+    /sbin/e-smith/config setprop dedalo_users_auth status enabled
+else
+    /sbin/e-smith/config setprop dedalo_users_auth status disabled
+fi
+
 # Apply configuration
 dedalo config

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-conf
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-conf
@@ -29,7 +29,7 @@ fi
 
 # Make sure dedalo_users_auth is started if the unit is registerd
 status=$(/sbin/e-smith/config getprop dedalo status)
-if [[ "$status" == "enabled" && -f "/root/.dedalo-token" ]]
+if [[ "$status" == "enabled" && -f "/root/.dedalo-token" ]]; then
     /sbin/e-smith/config setprop dedalo_users_auth status enabled
 else
     /sbin/e-smith/config setprop dedalo_users_auth status disabled

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-conf
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-conf
@@ -29,11 +29,7 @@ fi
 
 # Make sure dedalo_users_auth status is aligned to dedalo service
 status=$(/sbin/e-smith/config getprop dedalo status)
-if [[ "$status" == "enabled" ]]; then
-    /sbin/e-smith/config setprop dedalo_users_auth status enabled
-else
-    /sbin/e-smith/config setprop dedalo_users_auth status disabled
-fi
+/sbin/e-smith/config setprop dedalo_users_auth status "$status"
 
 # Apply configuration
 dedalo config

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-conf
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-conf
@@ -27,9 +27,9 @@ if [ -z "$uuid" ]; then
     /sbin/e-smith/config setprop dedalo Uuid $(uuidgen)
 fi
 
-# Make sure dedalo_users_auth is started if the unit is registerd
+# Make sure dedalo_users_auth status is aligned to dedalo service
 status=$(/sbin/e-smith/config getprop dedalo status)
-if [[ "$status" == "enabled" && -f "/root/.dedalo-token" ]]; then
+if [[ "$status" == "enabled" ]]; then
     /sbin/e-smith/config setprop dedalo_users_auth status enabled
 else
     /sbin/e-smith/config setprop dedalo_users_auth status disabled

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-conf
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-conf
@@ -28,7 +28,7 @@ if [ -z "$uuid" ]; then
 fi
 
 # Make sure dedalo_users_auth is started if the unit is registerd
-status=$(sbin/e-smith/config getprop dedalo status)
+status=$(/sbin/e-smith/config getprop dedalo status)
 if [[ "$status" == "enabled" && -f "/root/.dedalo-token" ]]
     /sbin/e-smith/config setprop dedalo_users_auth status enabled
 else

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-register
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-register
@@ -30,6 +30,7 @@ dedalo register -t $(cat $tmp_file)
 
 # Enable dedalo service
 /sbin/e-smith/config setprop dedalo status enabled
+/sbin/e-smith/config setprop dedalo_users_auth status enabled
 
 # Expand configuration using dedalo built-in template engine
 dedalo config

--- a/root/etc/e-smith/events/actions/nethserver-dedalo-unregister
+++ b/root/etc/e-smith/events/actions/nethserver-dedalo-unregister
@@ -22,8 +22,9 @@
 
 set -e
 
-# Enable dedalo service
+# Disable dedalo service
 /sbin/e-smith/config setprop dedalo status disabled Id ''
+/sbin/e-smith/config setprop dedalo_users_auth status disabled
 
 # retrieve internal unit ID
 dedalo_config=$(/sbin/e-smith/config getjson dedalo)


### PR DESCRIPTION
Make sure dedalo_users_auth is up&running if the unit has been
register and configured.
Also generate an alert if the service is not running.

NethServer/dev#6610