### PR TITLE
api. execute: move interface-update after dedalo registration

### DIFF
--- a/api/settings/registration/execute
+++ b/api/settings/registration/execute
@@ -28,6 +28,7 @@ import os
 import tempfile
 import shlex
 import ipaddress
+import time
 
 def register(input_json):
     hotspot_id = input_json['hotspotId']
@@ -106,6 +107,12 @@ def register(input_json):
 
             if return_code != 0:
                 return "Event failed, see /var/log/messages"
+
+            # after interface-update wait some seconds before launch registration.
+            # the nethserver-dedalo-register fails if executed immediately after
+            # interface-update
+            time.sleep(15)
+
     except Exception, e:
         return "Event failed, see /var/log/messages: %s" % e
 
@@ -133,7 +140,7 @@ def register(input_json):
                 return "Event failed, see /var/log/messages"
         except Exception, e:
             return "Event failed, see /var/log/messages: %s" % e
-            
+
 def unregister(input_json, logout_user):
     try:
         bash_command = "/sbin/e-smith/signal-event -j nethserver-dedalo-unregister"
@@ -159,7 +166,7 @@ try:
     elif app_info == 'unregister':
         logout = input_json["logout"]
         error = unregister(input_json, logout)
-        
+
     if error:
         output = simplejson.dumps({'state': 'error', 'message': error})
         print(output)

--- a/api/settings/registration/execute
+++ b/api/settings/registration/execute
@@ -28,7 +28,6 @@ import os
 import tempfile
 import shlex
 import ipaddress
-import time
 
 def register(input_json):
     hotspot_id = input_json['hotspotId']

--- a/api/settings/registration/execute
+++ b/api/settings/registration/execute
@@ -89,33 +89,6 @@ def register(input_json):
     except Exception, e:
         return "Error setting hotspot role for network %s: %s" % (network, e)
 
-    # perform interface-update if selected device is not physical, or at least an interface role has been removed (role_reset = True)
-    try:
-        bash_command = "/sbin/e-smith/db networks gettype %s" % network_device
-        process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
-        output, error = process.communicate()
-        return_code = process.returncode
-
-        if return_code != 0:
-            return "Event failed, see /var/log/messages"
-
-        if output.rstrip() != "ethernet" or role_reset:
-            bash_command = "/sbin/e-smith/signal-event -j interface-update"
-            process = subprocess.Popen(bash_command.split(), stdout=sys.stdout, stderr=sys.stderr)
-            output, error = process.communicate()
-            return_code = process.returncode
-
-            if return_code != 0:
-                return "Event failed, see /var/log/messages"
-
-            # after interface-update wait some seconds before launch registration.
-            # the nethserver-dedalo-register fails if executed immediately after
-            # interface-update
-            time.sleep(15)
-
-    except Exception, e:
-        return "Event failed, see /var/log/messages: %s" % e
-
     token_json = None
 
     # write token to temp file
@@ -140,6 +113,28 @@ def register(input_json):
                 return "Event failed, see /var/log/messages"
         except Exception, e:
             return "Event failed, see /var/log/messages: %s" % e
+
+    # perform interface-update if selected device is not physical, or at least an interface role has been removed (role_reset = True)
+    try:
+        bash_command = "/sbin/e-smith/db networks gettype %s" % network_device
+        process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        return_code = process.returncode
+
+        if return_code != 0:
+            return "Event failed, see /var/log/messages"
+
+        if output.rstrip() != "ethernet" or role_reset:
+            bash_command = "/sbin/e-smith/signal-event -j interface-update"
+            process = subprocess.Popen(bash_command.split(), stdout=sys.stdout, stderr=sys.stderr)
+            output, error = process.communicate()
+            return_code = process.returncode
+
+            if return_code != 0:
+                return "Event failed, see /var/log/messages"
+
+    except Exception, e:
+        return "Event failed, see /var/log/messages: %s" % e
 
 def unregister(input_json, logout_user):
     try:


### PR DESCRIPTION
The nethserver-dedalo-register fails if executed immediately after interface-update event. This is more reproducible when hotspot is configured on a vlan interface. Move the interface-update event after the dedalo registration.

https://github.com/NethServer/dev/issues/6717